### PR TITLE
#THE-599 vérification que la facette est peuplée dans FacetDrawer + a…

### DIFF
--- a/src/components/common/results/FacetDrawer.vue
+++ b/src/components/common/results/FacetDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-expansion-panels>
+  <v-expansion-panels v-if="date || Object.keys( facet.checkboxes ).length > 0">
     <v-expansion-panel class="elevation-0">
       <v-expansion-panel-title class="facet-title-panel">
         <h4 class="facet-title">

--- a/src/services/StrategyAPI.js
+++ b/src/services/StrategyAPI.js
@@ -372,15 +372,21 @@ function rawFacetReturnedFilter(facet, checkedFilterName) {
   }).length > 0;
 }
 
+function facetIsEmpty(facet) {
+  return Object.keys(facet.checkboxes).length < 1;
+}
+
 /**
  * Si les filtres cochés présents dans rawFacets ne sont pas dans la liste des facettes
  * retournées par l'API alors on les ajoute à cette même liste avec la valeur 0
+ * Seulement si la facette est peuplée
  * @param checkedFilterName
  * @param checkedFilterFacetName
  */
 function getCheckedFiltersBackIntoList(checkedFilterName, checkedFilterFacetName) {
   rawFacets.value.forEach((facet) => {
-    if (facet.name.toLowerCase() === checkedFilterFacetName.toLowerCase()) {
+    if ( !facetIsEmpty(facet)
+      && (facet.name.toLowerCase() === checkedFilterFacetName.toLowerCase()) ) {
       let currentFacet = { ...facet }; // cloner l'objet
       currentFacet.checkboxes = getFlattenedCheckboxesArray(facet);
 


### PR DESCRIPTION
…jout d'une condition dans StartegyAPI.getCheckedFiltersBackIntoList() : pour une facette vide ne pas ajouter les filtres cochés retournant 0 résultat et donc ne pas afficher le drawer de la facette